### PR TITLE
feat: save used apps

### DIFF
--- a/app/components/project/ProjectRunner.vue
+++ b/app/components/project/ProjectRunner.vue
@@ -8,22 +8,15 @@ let settings = await useSettings()
 
 const apps = computed(() => {
   return settings.value.apps.filter((app) => {
-    return props.project.used.includes(app.name);
+    return props.project.metadata.used.includes(app.name);
   })
 })
 
 async function onRunProject(app: App) {
   await invoke("run_project", {project: props.project, app: app})
-}
 
-function addToUsed(app: App) {
-  if (props.project.used.includes(app.name)) return
-
-  if (props.project.used.length >= 3) {
-    props.project.used.splice(0, 1)
-  }
-
-  props.project.used.push(app.name)
+  let metadata = await invoke("get_project_metadata", {project: props.project})
+  props.project.metadata = metadata;
 }
 </script>
 
@@ -47,10 +40,7 @@ function addToUsed(app: App) {
 
         <div class="group-hover:block hidden absolute w-max">
           <div class="mt-2 bg-zinc-600 p-2 rounded-lg flex flex-col gap-2">
-            <button v-for="app of settings.apps" :key="app.name" :value="app" @click="() => {
-                addToUsed(app)
-                onRunProject(app)
-            }">
+            <button v-for="app of settings.apps" :key="app.name" :value="app" @click="() => onRunProject(app)">
               <div class="flex gap-2 hover:scale-105 transition">
                 <AppIcon :app="app"/>
                 <div>

--- a/app/composables/useProjects.ts
+++ b/app/composables/useProjects.ts
@@ -5,6 +5,10 @@ import type {Settings} from "~/composables/useSettings";
 export type Project = {
     name: String
     path: String
+    metadata: ProjectMetaData
+}
+
+export type ProjectMetaData = {
     used: String[]
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub fn add_commands(app: Builder<Wry>) -> Builder<Wry> {
         settings::save_settings,
         projects::get_projects,
         projects::run_project,
+        projects::get_project_metadata,
         apps::get_all_apps,
     ])
 }

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -1,4 +1,4 @@
-use crate::projects::Project;
+use crate::projects::{Project, ProjectMetaData};
 use crate::settings::Settings;
 use applications::App;
 use tracing::error;
@@ -12,6 +12,14 @@ pub fn get_projects(settings: Settings) -> Result<Vec<Project>, String> {
 }
 
 #[tauri::command]
-pub fn run_project(project: Project, app: App) {
-    crate::projects::run_project(project, app)
+pub fn run_project(mut project: Project, mut app: App) {
+    crate::projects::run_project(&mut project, &mut app)
+}
+
+#[tauri::command]
+pub fn get_project_metadata(project: Project) -> Result<ProjectMetaData, String> {
+    crate::projects::get_metadata(&project.name).map_err(|err| {
+        error!("{}", err.to_string());
+        err.to_string()
+    })
 }

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -1,15 +1,23 @@
 use crate::error;
-use crate::settings::Settings;
+use crate::settings::{get_config_dir_path, Settings};
 use applications::App;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::fs::read_dir;
+use std::fs;
+use std::fs::{read_dir, read_to_string};
+use std::ops::Not;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 #[derive(Deserialize, Serialize)]
 pub struct Project {
-    name: String,
+    pub name: String,
     path: PathBuf,
+    metadata: ProjectMetaData,
+}
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct ProjectMetaData {
     used: Vec<String>,
 }
 
@@ -22,19 +30,62 @@ pub fn get_projects(settings: Settings) -> error::Result<Vec<Project>> {
         .filter_map(Result::ok)
         .filter(|e| e.path().is_dir())
         .filter(|dir| dir.file_name().into_string().is_ok())
-        .map(|dir| Project {
-            path: dir.path(),
-            name: dir.file_name().into_string().unwrap(),
-            used: vec![],
+        .map(|dir| {
+            let name = dir.file_name().into_string().unwrap();
+            Project {
+                path: dir.path(),
+                metadata: get_metadata(&name).unwrap(),
+                name,
+            }
         })
         .collect();
 
     Ok(names)
 }
 
-pub fn run_project(project: Project, app: App) {
+pub fn get_metadata(project_name: &str) -> error::Result<ProjectMetaData> {
+    let metadata_file_path = get_metadata_path(project_name)?;
+
+    if metadata_file_path.exists().not() {
+        return Ok(ProjectMetaData::default());
+    }
+
+    let file_content = fs::read_to_string(metadata_file_path)?;
+    Ok(serde_json::from_str(&file_content)?)
+}
+
+pub fn save_metadata(project_name: &str, metadata: &ProjectMetaData) -> error::Result<()> {
+    let metadata_file_path = get_metadata_path(project_name)?;
+
+    fs::create_dir_all(
+        &metadata_file_path
+            .parent()
+            .ok_or_else(|| "No Parent found")?,
+    )?;
+    fs::write(metadata_file_path, serde_json::to_string(metadata)?)?;
+
+    Ok(())
+}
+
+fn get_metadata_path(project_name: &str) -> error::Result<PathBuf> {
+    let config_dir_path = get_config_dir_path()?;
+    let metadata_file_path = config_dir_path
+        .join("meta")
+        .join(format!("{}.json", project_name));
+
+    Ok(metadata_file_path)
+}
+
+pub fn run_project(project: &mut Project, app: &App) {
     //TODO - https://github.com/HuakunShen/applications-rs/issues/5
-    let exec = app.app_path_exe.unwrap().to_str().unwrap().to_owned();
+    let exec = app
+        .app_path_exe
+        .as_ref()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
     let exec = exec
         .replace("%u", "")
         .replace("%F", "")
@@ -50,4 +101,25 @@ pub fn run_project(project: Project, app: App) {
         .stderr(Stdio::null())
         .spawn()
         .unwrap();
+
+    //add app to used list
+    let index = project
+        .metadata
+        .used
+        .iter()
+        .find_position(|name| name.eq(&&app.name));
+
+    match index {
+        None => {
+            if project.metadata.used.len() >= 3 {
+                project.metadata.used.pop();
+            }
+        }
+        Some((index, _)) => {
+            project.metadata.used.remove(index);
+        }
+    }
+
+    project.metadata.used.insert(0, app.name.to_string());
+    save_metadata(&project.name, &project.metadata).unwrap();
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -15,7 +15,7 @@ pub struct Settings {
 }
 
 pub fn get_settings() -> Result<Settings> {
-    let config_path = get_config_path()?;
+    let config_path = get_config_file_path()?;
     if config_path.exists().not() {
         return Ok(Settings::default());
     }
@@ -25,7 +25,7 @@ pub fn get_settings() -> Result<Settings> {
 }
 
 pub fn save_settings(settings: Settings) -> Result<()> {
-    let config_path = get_config_path()?;
+    let config_path = get_config_file_path()?;
 
     fs::create_dir_all(&config_path.parent().ok_or_else(|| "No Parent found")?)?;
     fs::write(config_path, serde_json::to_string(&settings)?)?;
@@ -33,9 +33,13 @@ pub fn save_settings(settings: Settings) -> Result<()> {
     Ok(())
 }
 
-fn get_config_path() -> Result<PathBuf> {
+fn get_config_file_path() -> Result<PathBuf> {
+    Ok(get_config_dir_path()?.join("settings.json"))
+}
+
+pub fn get_config_dir_path() -> Result<PathBuf> {
     let dirs = ProjectDirs::from("at", "tobinio", "Project Manager")
         .ok_or_else(|| "Invalid Project Dirs")?;
 
-    Ok(dirs.config_dir().to_path_buf().join("settings.json"))
+    Ok(dirs.config_dir().to_path_buf())
 }


### PR DESCRIPTION
This adds a new concept - the project metadata will contain all additional information the app needs to save, currently this is only a list of application

these are stored at `<config-dir>/meta/<project-name>.json`